### PR TITLE
fix yaxis regular expression

### DIFF
--- a/chipplot.py
+++ b/chipplot.py
@@ -40,8 +40,8 @@ def plot_bandwidth(db, plotfile, view=False):
   for ylabel in ax1.get_yticklabels():
     ytext = ylabel.get_text()
     if ytext:
-      m = re.search('mathdefault\{10\^\{(.*)\}\}', ytext)
-      exp = int(m.group(1))
+      m = re.findall('\d+', ytext)
+      exp = int(m[1])
       assert exp >= 0
       for unit in ['bps', 'kbps', 'Mbps', 'Gbps', 'Tbps', 'Pbps', 'Ebps',
                    'Zbps', 'Ybps']:


### PR DESCRIPTION
Sorry somewhat late, 
First of all, I think I should write down my settings 

OS : Ubuntu 14.04.3 LTS
Python : 3.4.3

It seems like the original version of regular expression doesn't match with the pattern from ytext.
For me, the ytext is

${10^{9}}$
${10^{10}}$
${10^{11}}$
....

When I execute the code, I got an error

**AttributeError: 'NoneType' object has no attribute 'group'**
I managed to figure out the error comes from not working the regular expression matching. 

So, I suggest different type of matching!!
I hope that is work. 
Thank you and have a nice day!
